### PR TITLE
merging in new QTL COLOC features - and cleaning up run_COLOC.R

### DIFF
--- a/COLOC/Snakefile
+++ b/COLOC/Snakefile
@@ -7,15 +7,21 @@ outFolder = config["outFolder"]
 geneMeta = config["geneMeta"]
 
 # sanity check - can the GWAS and QTL data be found in the database?
-gwas_df = pd.read_excel("/sc/arion/projects/ad-omics/data/references//GWAS/GWAS-QTL_data_dictionary.xlsx", sheet_name = 2)
-qtl_df = pd.read_excel("/sc/arion/projects/ad-omics/data/references//GWAS/GWAS-QTL_data_dictionary.xlsx", sheet_name = 1)
+gwas_df = pd.read_excel("/sc/arion/projects/ad-omics/data/references//GWAS/GWAS-QTL_data_dictionary.xlsx", sheet_name = 1)
+qtl_df = pd.read_excel("/sc/arion/projects/ad-omics/data/references//GWAS/GWAS-QTL_data_dictionary.xlsx", sheet_name = 2)
 
 gwas_check = all(i in gwas_df["dataset"].tolist() for i in gwas_data )
 qtl_check = all(i in qtl_df["dataset"].tolist() for i in qtl_data )
 
-if not all([gwas_check, qtl_check]):
-    print(" * QTL and/or GWAS cannot be found in database")
+if not all([gwas_check]):
+    print(" * GWAS cannot be found in database")
     sys.exit()
+
+if not all([qtl_check]):
+    print(" * QTL cannot be found in database")
+    print(qtl_check)
+    sys.exit()
+
 
 shell.prefix("export PS1=""; ml anaconda3; CONDA_BASE=$(conda info --base); source $CONDA_BASE/etc/profile.d/conda.sh; ml purge; conda activate snakemake;")
 rule all:
@@ -23,6 +29,7 @@ rule all:
         #expand(outFolder + "{GWAS}/{QTL}/{QTL}_{GWAS}_coloc_results.snp.1kgp3_ld.tsv.gz", GWAS = gwas_data, QTL = qtl_data)
         outFolder + "all_COLOC_results_merged_H4_0_no_LD.tsv.gz",
         outFolder + "all_COLOC_results_merged_H4_0.5_with_LD.tsv.gz",
+        outFolder + "pairwise_QTL_results.tsv.gz"
         #expand( outFolder + "{GWAS}/{QTL}_{GWAS}_COLOC.tsv", GWAS = gwas_data, QTL = qtl_data )
         #outFolder + "all_COLOC_summary_results.tsv.gz"
 
@@ -46,7 +53,7 @@ rule merge_COLOC_snp_level:
     params:
         script = "scripts/merge_COLOC_results.R"
     shell:
-        "ml R/4.0.3;"
+        "ml R/3.6.0;" # LDLINKR only installed on 3.6
         "Rscript {params.script} --threshold 0 --inFolder {outFolder} --geneMeta {geneMeta};" 
         "Rscript {params.script} --threshold 0.5 --ld --inFolder {outFolder} --geneMeta {geneMeta} "
 
@@ -61,3 +68,25 @@ rule create_LD_tables:
     shell:
        "conda activate echoR;"
        "Rscript {params.script} -g {wildcards.GWAS} -q {wildcards.QTL} --inFile {input} --outFolder {params.out}" 
+
+rule prepare_QTL_COLOC:
+    input:
+        outFolder + "all_COLOC_results_merged_H4_0.5_with_LD.tsv.gz"
+    output:
+        outFolder + "pairwise_QTL_COLOC_targets.tsv.gz"
+    params:
+        script = "scripts/prepare_pairwise_qtl_coloc.R"
+    shell:
+        "ml R/4.2.0;"
+        "Rscript {params.script} -i {input} -o {output} -m across -p 0.8"
+
+rule run_QTL_COLOC:
+    input:
+        outFolder + "pairwise_QTL_COLOC_targets.tsv.gz"
+    output:
+        outFolder + "pairwise_QTL_results.tsv.gz"
+    params:
+        script = "scripts/run_COLOC.R"
+    shell:
+        "ml R/4.2.0;"
+        "Rscript {params.script} -t {input} -o {output}"

--- a/COLOC/Snakefile
+++ b/COLOC/Snakefile
@@ -5,7 +5,7 @@ gwas_data = config["gwas"]
 qtl_data = config["qtl"]
 outFolder = config["outFolder"]
 geneMeta = config["geneMeta"]
-
+sig_threshold = config["sig_threshold"]
 # sanity check - can the GWAS and QTL data be found in the database?
 gwas_df = pd.read_excel("/sc/arion/projects/ad-omics/data/references//GWAS/GWAS-QTL_data_dictionary.xlsx", sheet_name = 1)
 qtl_df = pd.read_excel("/sc/arion/projects/ad-omics/data/references//GWAS/GWAS-QTL_data_dictionary.xlsx", sheet_name = 2)
@@ -29,7 +29,7 @@ rule all:
         #expand(outFolder + "{GWAS}/{QTL}/{QTL}_{GWAS}_coloc_results.snp.1kgp3_ld.tsv.gz", GWAS = gwas_data, QTL = qtl_data)
         outFolder + "all_COLOC_results_merged_H4_0_no_LD.tsv.gz",
         outFolder + "all_COLOC_results_merged_H4_0.5_with_LD.tsv.gz",
-        outFolder + "pairwise_QTL_results.tsv.gz"
+        #outFolder + "pairwise_QTL_results.tsv.gz"
         #expand( outFolder + "{GWAS}/{QTL}_{GWAS}_COLOC.tsv", GWAS = gwas_data, QTL = qtl_data )
         #outFolder + "all_COLOC_summary_results.tsv.gz"
 
@@ -41,8 +41,8 @@ rule run_COLOC:
         script = "scripts/run_COLOC.R"
     shell:
         "mkdir -p {outFolder}{wildcards.GWAS};"
-        "ml R/4.0.3;" #ml arrow;"
-        "Rscript {params.script} -g {wildcards.GWAS} -q {wildcards.QTL} -o {outFolder}{wildcards.GWAS}/ "
+        "ml R;" #ml arrow;"
+        "Rscript {params.script} -g {wildcards.GWAS} -q {wildcards.QTL} -o {outFolder}{wildcards.GWAS}/ -s 1e-5 --verbose --lowmem"
    
 rule merge_COLOC_snp_level:
     input:
@@ -53,7 +53,7 @@ rule merge_COLOC_snp_level:
     params:
         script = "scripts/merge_COLOC_results.R"
     shell:
-        "ml R/3.6.0;" # LDLINKR only installed on 3.6
+        "ml R;" # LDLINKR only installed on 3.6
         "Rscript {params.script} --threshold 0 --inFolder {outFolder} --geneMeta {geneMeta};" 
         "Rscript {params.script} --threshold 0.5 --ld --inFolder {outFolder} --geneMeta {geneMeta} "
 

--- a/COLOC/cluster.yaml
+++ b/COLOC/cluster.yaml
@@ -1,5 +1,4 @@
 __default__:
-  #partition: chimera
   queue: premium
   cores: 1
   mem: 24000
@@ -8,3 +7,7 @@ __default__:
   output: logs/{rule}:{wildcards}.stdout
   error: logs/{rule}:{wildcards}.stderr
   himem: ""
+pairwise_QTL_COLOC:
+  cores: 4
+  mem: 8000
+  time: 8640

--- a/COLOC/cluster.yaml
+++ b/COLOC/cluster.yaml
@@ -1,7 +1,7 @@
 __default__:
   queue: premium
   cores: 1
-  mem: 24000
+  mem: 48000
   time: '120'
   name: $(basename $(pwd)):{rule}:{wildcards}
   output: logs/{rule}:{wildcards}.stdout
@@ -9,5 +9,5 @@ __default__:
   himem: ""
 pairwise_QTL_COLOC:
   cores: 4
-  mem: 8000
+  mem: 16000
   time: 8640

--- a/COLOC/pairwise_qtl_coloc.smk
+++ b/COLOC/pairwise_qtl_coloc.smk
@@ -1,0 +1,78 @@
+import sys
+import pandas as pd
+# Pairwise QTL COLOC pipeline
+
+outFolder = config["outFolder"]
+inFolder = config["inFolder"]
+
+target_files = [ x for x in glob.glob(inFolder + "/*genewide_QTL_pairs*tsv.gz" )]
+
+
+
+shell.prefix("export PS1=""; ml anaconda3; CONDA_BASE=$(conda info --base); source $CONDA_BASE/etc/profile.d/conda.sh; ml purge; conda activate snakemake;")
+rule all:
+    input:
+        #expand(outFolder + "{GWAS}/{QTL}/{QTL}_{GWAS}_coloc_results.snp.1kgp3_ld.tsv.gz", GWAS = gwas_data, QTL = qtl_data)
+        #outFolder + "all_COLOC_results_merged_H4_0_no_LD.tsv.gz",
+        #outFolder + "all_COLOC_results_merged_H4_0.5_with_LD.tsv.gz",
+        #outFolder + "pairwise_QTL_results.tsv.gz"
+        #expand( outFolder + "{GWAS}/{QTL}_{GWAS}_COLOC.tsv", GWAS = gwas_data, QTL = qtl_data )
+        #outFolder + "all_COLOC_summary_results.tsv.gz"
+
+rule run_COLOC:
+    output:
+        outFolder + "{GWAS}/{QTL}_{GWAS}_COLOC.tsv",
+        outFolder +  "{GWAS}/{QTL}_{GWAS}_COLOC.RData"
+    params:
+        script = "scripts/run_COLOC.R"
+    shell:
+        "mkdir -p {outFolder}{wildcards.GWAS};"
+        "ml R/4.0.3;" #ml arrow;"
+        "Rscript {params.script} -g {wildcards.GWAS} -q {wildcards.QTL} -o {outFolder}{wildcards.GWAS}/ "
+   
+rule merge_COLOC_snp_level:
+    input:
+        expand( outFolder + "{GWAS}/{QTL}_{GWAS}_COLOC.tsv", GWAS = gwas_data, QTL = qtl_data )
+    output:
+        outFolder + "all_COLOC_results_merged_H4_0_no_LD.tsv.gz",
+        outFolder + "all_COLOC_results_merged_H4_0.5_with_LD.tsv.gz"
+    params:
+        script = "scripts/merge_COLOC_results.R"
+    shell:
+        "ml R/3.6.0;" # LDLINKR only installed on 3.6
+        "Rscript {params.script} --threshold 0 --inFolder {outFolder} --geneMeta {geneMeta};" 
+        "Rscript {params.script} --threshold 0.5 --ld --inFolder {outFolder} --geneMeta {geneMeta} "
+
+rule create_LD_tables:
+    input:
+        outFolder +  "{GWAS}/{QTL}_{GWAS}_COLOC.RData"
+    output:
+        outFolder +  "{GWAS}/{QTL}/{QTL}_{GWAS}_coloc_results.snp.1kgp3_ld.tsv.gz"
+    params:
+        script = "scripts/prepare_gwas_qtls.R",
+        out = outFolder +  "{GWAS}/{QTL}/"
+    shell:
+       "conda activate echoR;"
+       "Rscript {params.script} -g {wildcards.GWAS} -q {wildcards.QTL} --inFile {input} --outFolder {params.out}" 
+
+rule prepare_QTL_COLOC:
+    input:
+        outFolder + "all_COLOC_results_merged_H4_0.5_with_LD.tsv.gz"
+    output:
+        outFolder + "pairwise_QTL_COLOC_targets.tsv.gz"
+    params:
+        script = "scripts/prepare_pairwise_qtl_coloc.R"
+    shell:
+        "ml R/4.2.0;"
+        "Rscript {params.script} -i {input} -o {output} -m across -p 0.8"
+
+rule run_QTL_COLOC:
+    input:
+        outFolder + "pairwise_QTL_COLOC_targets.tsv.gz"
+    output:
+        outFolder + "pairwise_QTL_results.tsv.gz"
+    params:
+        script = "scripts/run_COLOC.R"
+    shell:
+        "ml R/4.2.0;"
+        "Rscript {params.script} -t {input} -o {output}"

--- a/COLOC/pairwise_qtl_coloc.smk
+++ b/COLOC/pairwise_qtl_coloc.smk
@@ -1,78 +1,30 @@
 import sys
 import pandas as pd
-# Pairwise QTL COLOC pipeline
+import glob
+import re
+import os
 
+# Pairwise QTL COLOC pipeline
+# Jack Humphrey
 outFolder = config["outFolder"]
 inFolder = config["inFolder"]
 
-target_files = [ x for x in glob.glob(inFolder + "/*genewide_QTL_pairs*tsv.gz" )]
-
+target_files = [ x for x in glob.glob(inFolder + "*genewide_QTL_pairs*tsv.gz" )]
+target_ids = [os.path.basename(re.sub('.tsv.gz', '', x, count=1)) for x in target_files ]
 
 
 shell.prefix("export PS1=""; ml anaconda3; CONDA_BASE=$(conda info --base); source $CONDA_BASE/etc/profile.d/conda.sh; ml purge; conda activate snakemake;")
 rule all:
     input:
-        #expand(outFolder + "{GWAS}/{QTL}/{QTL}_{GWAS}_coloc_results.snp.1kgp3_ld.tsv.gz", GWAS = gwas_data, QTL = qtl_data)
-        #outFolder + "all_COLOC_results_merged_H4_0_no_LD.tsv.gz",
-        #outFolder + "all_COLOC_results_merged_H4_0.5_with_LD.tsv.gz",
-        #outFolder + "pairwise_QTL_results.tsv.gz"
-        #expand( outFolder + "{GWAS}/{QTL}_{GWAS}_COLOC.tsv", GWAS = gwas_data, QTL = qtl_data )
-        #outFolder + "all_COLOC_summary_results.tsv.gz"
+        expand( outFolder + "{target}_COLOC.tsv.gz", target = target_ids)
 
-rule run_COLOC:
+rule pairwise_QTL_COLOC:
+    input:
+        inFolder + "{target}.tsv.gz"
     output:
-        outFolder + "{GWAS}/{QTL}_{GWAS}_COLOC.tsv",
-        outFolder +  "{GWAS}/{QTL}_{GWAS}_COLOC.RData"
+        outFolder + "{target}_COLOC.tsv.gz"
     params:
         script = "scripts/run_COLOC.R"
     shell:
-        "mkdir -p {outFolder}{wildcards.GWAS};"
-        "ml R/4.0.3;" #ml arrow;"
-        "Rscript {params.script} -g {wildcards.GWAS} -q {wildcards.QTL} -o {outFolder}{wildcards.GWAS}/ "
-   
-rule merge_COLOC_snp_level:
-    input:
-        expand( outFolder + "{GWAS}/{QTL}_{GWAS}_COLOC.tsv", GWAS = gwas_data, QTL = qtl_data )
-    output:
-        outFolder + "all_COLOC_results_merged_H4_0_no_LD.tsv.gz",
-        outFolder + "all_COLOC_results_merged_H4_0.5_with_LD.tsv.gz"
-    params:
-        script = "scripts/merge_COLOC_results.R"
-    shell:
-        "ml R/3.6.0;" # LDLINKR only installed on 3.6
-        "Rscript {params.script} --threshold 0 --inFolder {outFolder} --geneMeta {geneMeta};" 
-        "Rscript {params.script} --threshold 0.5 --ld --inFolder {outFolder} --geneMeta {geneMeta} "
-
-rule create_LD_tables:
-    input:
-        outFolder +  "{GWAS}/{QTL}_{GWAS}_COLOC.RData"
-    output:
-        outFolder +  "{GWAS}/{QTL}/{QTL}_{GWAS}_coloc_results.snp.1kgp3_ld.tsv.gz"
-    params:
-        script = "scripts/prepare_gwas_qtls.R",
-        out = outFolder +  "{GWAS}/{QTL}/"
-    shell:
-       "conda activate echoR;"
-       "Rscript {params.script} -g {wildcards.GWAS} -q {wildcards.QTL} --inFile {input} --outFolder {params.out}" 
-
-rule prepare_QTL_COLOC:
-    input:
-        outFolder + "all_COLOC_results_merged_H4_0.5_with_LD.tsv.gz"
-    output:
-        outFolder + "pairwise_QTL_COLOC_targets.tsv.gz"
-    params:
-        script = "scripts/prepare_pairwise_qtl_coloc.R"
-    shell:
-        "ml R/4.2.0;"
-        "Rscript {params.script} -i {input} -o {output} -m across -p 0.8"
-
-rule run_QTL_COLOC:
-    input:
-        outFolder + "pairwise_QTL_COLOC_targets.tsv.gz"
-    output:
-        outFolder + "pairwise_QTL_results.tsv.gz"
-    params:
-        script = "scripts/run_COLOC.R"
-    shell:
-        "ml R/4.2.0;"
-        "Rscript {params.script} -t {input} -o {output}"
+        "ml R;" 
+        "Rscript {params.script} --targets {input} -o {outFolder} --lowmem --threads 1"

--- a/COLOC/pairwise_qtl_coloc.smk
+++ b/COLOC/pairwise_qtl_coloc.smk
@@ -8,8 +8,9 @@ import os
 # Jack Humphrey
 outFolder = config["outFolder"]
 inFolder = config["inFolder"]
+MAF_file = config["MAF_file"]
 
-target_files = [ x for x in glob.glob(inFolder + "*genewide_QTL_pairs*tsv.gz" )]
+target_files = [ x for x in glob.glob(inFolder + "*genewide*pairs*tsv.gz" )]
 target_ids = [os.path.basename(re.sub('.tsv.gz', '', x, count=1)) for x in target_files ]
 
 
@@ -27,4 +28,4 @@ rule pairwise_QTL_COLOC:
         script = "scripts/run_COLOC.R"
     shell:
         "ml R;" 
-        "Rscript {params.script} --targets {input} -o {outFolder} --lowmem --threads 1"
+        "Rscript {params.script} --targets {input} -o {outFolder} --lowmem --threads 1 --MAF {MAF_file}"

--- a/COLOC/scripts/prepare_pairwise_qtl_coloc.R
+++ b/COLOC/scripts/prepare_pairwise_qtl_coloc.R
@@ -1,0 +1,73 @@
+library(optparse)
+
+option_list <- list(
+        make_option(c('-o', '--outFile'), help='the path to the output file', default = ""),
+        make_option(c('-i', '--inFile'), help='the path to the input file', default = ""),
+        make_option(c('-m', '--mode'), help='mode - across or within?', default = "across"),
+        make_option(c('-p', '--pp'), help='min PP4', default = 0.5),
+        make_option(c('--debug'), help = "load all files and then save RData without running COLOC", action = "store_true", default = FALSE)
+)
+
+option.parser <- OptionParser(option_list=option_list)
+opt <- parse_args(option.parser)
+
+inFile <- opt$inFile
+outFile <- opt$outFile
+mode <- opt$mode
+PP4 <- opt$pp
+library(tidyverse)
+
+#all_coloc <- read_tsv("../all_COLOC_results_merged_H4_0.5_with_LD.tsv.gz")
+all_coloc <- read_tsv(inFile)
+
+all_coloc$distance <- abs(all_coloc$GWAS_pos - all_coloc$QTL_pos)
+all_coloc$distance_filter <- (!is.na(all_coloc$LD) & all_coloc$LD > 0.1) | all_coloc$distance < 5e5
+
+qtl_coloc_input <- all_coloc %>%
+  filter(distance_filter == TRUE & PP.H4.abf > PP4) %>%
+  select(GWAS, QTL, locus, feature) %>%
+  distinct()
+
+message(" * ", nrow(qtl_coloc_input), " phenotypes colocalize at PP4 > ", PP4)
+stopifnot( nrow(qtl_coloc_input) > 0)
+
+
+shared_loci <- select(qtl_coloc_input, GWAS, locus, QTL) %>%
+  distinct() %>%
+  group_by(GWAS, locus) %>%
+  tally() %>%
+  filter(n > 1)
+message(" * ", nrow(shared_loci), " loci are shared between QTL types")
+stopifnot( nrow(shared_loci) > 0)
+
+qtl_coloc_input  <- filter(qtl_coloc_input, locus %in% shared_loci$locus)
+
+# get all pairwise comparisons required
+# make optional - do you want to test features within a dataset or just across?
+qtl_coloc_split <- qtl_coloc_input %>%
+  split(paste0(.$GWAS, ":", .$locus)) %>%
+  map_df( ~{
+    d <- select(.x, GWAS,locus, QTL, feature) %>% distinct() 
+    qtl_pairs <- combn(unique(paste(d$QTL, d$feature) ), 2)
+    locus_df <- select(d, GWAS, locus)
+    pair_df <- 
+      data.frame(qtl_1 = qtl_pairs[1,], qtl_2 = qtl_pairs[2,] ) %>%
+      tidyr::separate(qtl_1, into = c("qtl_1", "feature_1"), sep = " ") %>%
+      tidyr::separate(qtl_2, into = c("qtl_2", "feature_2"), sep = " ") %>%
+      mutate(GWAS = unique(d$GWAS), locus = unique(d$locus)) %>%
+      select(GWAS, locus, everything() )
+
+  }) %>%
+  distinct()
+
+if( mode == "across"){
+
+qtl_coloc_split <- qtl_coloc_split %>%
+ mutate( within = qtl_1 == qtl_2) %>% filter(within == FALSE)
+}
+
+write_tsv(qtl_coloc_split, outFile) #"test_eQTL_edQTL_pairwise_input.tsv")
+
+
+
+ 

--- a/COLOC/scripts/run_COLOC.R
+++ b/COLOC/scripts/run_COLOC.R
@@ -438,6 +438,8 @@ extractQTL <- function(qtl, coord, sig_level = 0.05, force_maf = FALSE, targets 
     }else{
         res_subset <- dplyr::select(result, gene, snp, pvalues, MAF, QTL_chr, QTL_pos)
     }
+    # edge case - multiallelic SNPs lead to two entries per SNP-gene - remove
+    res_subset <- dplyr::distinct(res_subset)
     #print(head(res_subset) ) 
     print("passed this point")
     #dplyr::filter( pos >= coord_split$start & pos <= coord_split$end)

--- a/COLOC/scripts/run_COLOC.R
+++ b/COLOC/scripts/run_COLOC.R
@@ -367,8 +367,8 @@ extractQTL_tabix <- function(qtl, coord){
 
 # extract all nominal QTL P-values overlapping the flanked GWAS hit
 # split by Gene being tested
-# sig_level doesn't do anything yet
-extractQTL <- function(qtl, coord, sig_level = 0.05, force_maf = FALSE, targets = NULL){
+# now implemented sig_level filtering for minimum P-value for each phenotype
+extractQTL <- function(qtl, coord, sig_level = NULL, force_maf = FALSE, targets = NULL){
     # variables stored in qtl
     # if qtl type is parquet then read in parquet files
     # if qtl type is tabix then query the coordinates through tabix 
@@ -423,7 +423,18 @@ extractQTL <- function(qtl, coord, sig_level = 0.05, force_maf = FALSE, targets 
     if( pvalCol == "log10_p"){
         result$pvalues <- 10^result$pvalues
     }
-
+    # P-value thresholding - methylation QTLs, there are way too many sites to test all of them
+    if( !is.null(sig_level) ){
+        message_verbose(paste0(" currently: ", length(unique(result$gene) ), " phenotypes in window" ) )
+        message_verbose(paste0(" removing phenotypes with P < ", sig_level))
+        pheno_p <- result %>% dplyr::group_by(gene) %>% dplyr::slice_min(pvalues, n = 1, with_ties = FALSE) %>% dplyr::filter(pvalues < as.numeric(sig_level) )
+        result <- dplyr::filter(result, gene %in% pheno_p$gene)
+        if(nrow(result) == 0){
+            message_verbose(" 0 phenotypes remaining after P thresholding")
+            return(NULL)
+        }
+        message_verbose(paste0("retaining ", nrow(result), " associations from ", nrow(pheno_p), " phenotypes" ))
+    }
     # deal with MAF - meta-analysis outputs won't have it
     # this requires "chr" to be present in QTL data
     #if( debug == TRUE){ result$MAF <- NA }else{ # why do we do this? breaks it when debug is TRUE
@@ -582,7 +593,7 @@ runCOLOC <- function(gwas, qtl, qtl2 = NULL, hit, sig.level = NULL, target.file 
         qtl_range <- joinCoords(qtl_coord, flank = 1e6)
     }
     message_verbose("extracting QTLs")
-    q <- extractQTL(qtl, qtl_range, targets = target.file[1])
+    q <- extractQTL(qtl, qtl_range, targets = target.file[1], sig_level = sig.level)
     #print(names(q[[1]]))
     if( is.null(q) ){ return(NULL) }
     qtl_info <- getQTLinfo(q, hit_info)
@@ -827,7 +838,10 @@ main <- function(){
         names(all_obj) <- top_loci$locus
     }
     dir.create(outFolder,  showWarnings = FALSE)
-    all_res <- dplyr::arrange(all_res, desc(PP.H4.abf)  )
+    # in case all COLOCs are null for some reason
+    if(nrow(all_res) > 0){
+        all_res <- dplyr::arrange(all_res, desc(PP.H4.abf)  )
+    }
     message("finished COLOC pipeline")
     message_verbose(paste0("writing output to ", outFile))
     readr::write_tsv(all_res, file = outFile)

--- a/GWAS/processGWAS.R
+++ b/GWAS/processGWAS.R
@@ -81,7 +81,7 @@ get_standard_error <- function(OR, P){
 # write out sorted file to reference folder
 # tabix index the file
 # Ripke has loci with chr23 for X - remove
-sortGWAS <- function(gwas, out_folder = "./"){
+sortGWAS <- function(gwas, out_folder = ""){
     dataset <- gwas$dataset
     
     col_chr <- gwas$full_chrom
@@ -127,7 +127,7 @@ sortGWAS <- function(gwas, out_folder = "./"){
     # remove duplicate rows
     gwas_sorted <- dplyr::distinct(gwas_sorted)
     
-    out_path <- paste0(out_folder, dataset, ".processed.tsv")
+    out_path <- file.path(out_folder, paste0(dataset, ".processed.tsv") )
     message(Sys.time()," * writing sorted GWAS file to ", out_path)
     readr::write_tsv(gwas_sorted, out_path)
     stopifnot(file.exists(out_path) )

--- a/qvalue_sharing/Snakefile
+++ b/qvalue_sharing/Snakefile
@@ -18,7 +18,7 @@ rule run_qvalue:
     output:
         outFolder + "{source}:{target}:{threshold}.qvalue.tsv"
     shell:
-        "ml R/3.6.0;"
+        "ml R;"
         "Rscript {params.script} -s {params.source} -t {params.target} -q {threshold} -o {outFolder}"
 
 rule merge_qvalue:
@@ -29,5 +29,5 @@ rule merge_qvalue:
     output:
         outFolder + "all_qvalue_merged." + threshold + ".tsv"
     shell:
-        "ml R/3.6.0;"
+        "ml R;"
         "Rscript {params.script} -o {outFolder} -q {threshold}"

--- a/qvalue_sharing/run_qvalue.R
+++ b/qvalue_sharing/run_qvalue.R
@@ -11,10 +11,10 @@ pullData <- function(dataset, type = "GWAS"){
     message(Sys.time()," * reading GWAS database from ", db_path)
     stopifnot( file.exists(db_path) )
     if( type == "GWAS"){
-        n_sheet <- 3
+        n_sheet <- 2
     }
     if( type == "QTL"){
-        n_sheet <- 2
+        n_sheet <- 3
     }
     gwas_db <- suppressMessages(readxl::read_excel(db_path, sheet = n_sheet,na= c("", "-","NA")))
     
@@ -78,7 +78,7 @@ extractTargetQTL <- function(qtl, chr, source_qtls){
     stopifnot( file.exists(qtl$full_path) )
      
     # read in QTL
-    cmd <- paste0("ml bcftools; tabix ", qtl$full_path, " ", chr)
+    cmd <- paste0("ml tabix; tabix ", qtl$full_path, " ", chr)
     message( " * ", cmd) 
     result <- data.table::fread( cmd = cmd, nThread = 8 )
     if( nrow(result) == 0){ 


### PR DESCRIPTION
this extends run_COLOC to allow pairwise colocalization of different QTL features, using a target file which specifies each pair of QTL datasets and each pair of QTL features to colocalize together.

the Snakefile now includes a script to make the target file from a COLOC summary table, picking pairs of features in the same locus that both colocalize with a GWAS (PP4 > 0.8 but can be changed).